### PR TITLE
Correctly parse complex locale identifiers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -263,7 +263,8 @@ const api = new Api({
 });
 
 const locale = navigator.language;
-const translations = navigator.language == "de" ? de : en;
+const normalizedLanguage = new Intl.Locale(locale).language;
+const translations = normalizedLanguage == "de" ? de : en;
 
 const loadedMeals = ref<Meal[]>([]);
 const todaysDate = new Date();
@@ -301,7 +302,7 @@ async function loadMeals(date: Date) {
     if (!mensa.value) return;
     const response = await api.meals.getMeals(mensa.value, {
       date: date.toISOString().split("T")[0],
-      lang: locale == "de" ? "de" : "en",
+      lang: normalizedLanguage == "de" ? "de" : "en",
     });
 
     if (response.error) {


### PR DESCRIPTION
This PR adds support for complex locale identifiers, such as `de-DE`. All locales with German language will now be considered German for the localization of the application and for fetching the meals.

Currently, only `de` is detected as German and all other identifiers (including `de-DE`) fall back to English as default.