### PR TITLE
Add button to switch the language

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -273,7 +273,7 @@ const api = new Api({
 });
 
 const locale = navigator.language;
-let normalizedLanguage = ref(new Intl.Locale(locale).language);
+const normalizedLanguage = ref(new Intl.Locale(locale).language);
 const translations = normalizedLanguage.value == "de" ? de : en;
 
 const loadedMeals = ref<Meal[]>([]);

--- a/src/App.vue
+++ b/src/App.vue
@@ -303,7 +303,6 @@ function toggleLanguage() {
   } else {
     normalizedLanguage.value = "de";
   }
-  console.log(normalizedLanguage);
 }
 
 function increaseDate(inc: number) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -274,7 +274,9 @@ const api = new Api({
 
 const locale = navigator.language;
 const normalizedLanguage = ref(new Intl.Locale(locale).language);
-const translations = normalizedLanguage.value == "de" ? de : en;
+const translations = computed(() =>
+  normalizedLanguage.value == "de" ? de : en,
+);
 
 const loadedMeals = ref<Meal[]>([]);
 const todaysDate = new Date();
@@ -368,10 +370,10 @@ loadMeals(date.value);
 const mealList = computed(() => {
   if (!loadedMeals.value.length) {
     if (state.value == State.EMPTY) {
-      return [{ type: "subheader", title: translations.nomeals }];
+      return [{ type: "subheader", title: translations.value.nomeals }];
     }
     if (state.value == State.LOADING) {
-      return [{ type: "subheader", title: translations.loading }];
+      return [{ type: "subheader", title: translations.value.loading }];
     }
   }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
           @click.stop="drawer = !drawer"
         ></v-app-bar-nav-icon>
         <v-app-bar-title> Mensa {{ mensa }} </v-app-bar-title>
+        <v-btn @click="toggleLanguage()" :icon="mdiTranslate"></v-btn>
         <v-btn @click="theme.toggle()" :icon="mdiThemeLightDark"></v-btn>
       </v-app-bar>
 
@@ -241,7 +242,16 @@ import { useTheme } from "vuetify";
 import { de, en } from "@/lib/translations";
 import type { Configuration } from "@/lib/config";
 
-import { mdiChevronLeft, mdiChevronRight,mdiThemeLightDark,mdiInformation,mdiClose,mdiMoonWaxingCrescent,mdiWhiteBalanceSunny } from '@mdi/js'
+import {
+  mdiChevronLeft,
+  mdiChevronRight,
+  mdiThemeLightDark,
+  mdiInformation,
+  mdiClose,
+  mdiMoonWaxingCrescent,
+  mdiWhiteBalanceSunny,
+  mdiTranslate,
+} from "@mdi/js";
 
 declare global {
   // Note the capital "W"
@@ -263,8 +273,8 @@ const api = new Api({
 });
 
 const locale = navigator.language;
-const normalizedLanguage = new Intl.Locale(locale).language;
-const translations = normalizedLanguage == "de" ? de : en;
+let normalizedLanguage = ref(new Intl.Locale(locale).language);
+const translations = normalizedLanguage.value == "de" ? de : en;
 
 const loadedMeals = ref<Meal[]>([]);
 const todaysDate = new Date();
@@ -285,6 +295,15 @@ enum State {
 
 const state = ref<State>(State.LOADING);
 
+function toggleLanguage() {
+  if (normalizedLanguage.value === "de") {
+    normalizedLanguage.value = "en";
+  } else {
+    normalizedLanguage.value = "de";
+  }
+  console.log(normalizedLanguage);
+}
+
 function increaseDate(inc: number) {
   const newDate = new Date(date.value);
   newDate.setDate(date.value.getDate() + inc);
@@ -302,7 +321,7 @@ async function loadMeals(date: Date) {
     if (!mensa.value) return;
     const response = await api.meals.getMeals(mensa.value, {
       date: date.toISOString().split("T")[0],
-      lang: normalizedLanguage == "de" ? "de" : "en",
+      lang: normalizedLanguage.value == "de" ? "de" : "en",
     });
 
     if (response.error) {
@@ -373,7 +392,7 @@ const mealList = computed(() => {
         : mdiWhiteBalanceSunny,
       title: meal.name,
       subtitle: `<strong class="text-primary">${meal.studentPrice.toFixed(
-        2
+        2,
       )}€</strong> &bull; ${shortFeatureString} &bull; ${shortAllergenString} &bull; ${shortAdditivesString}`,
       meal: meal,
     };
@@ -396,6 +415,10 @@ watch(date, async (newDate, oldDate) => {
   await loadMeals(newDate);
 });
 watch(location, async (newLocation, oldLocation) => {
+  date.value.setHours(12);
+  await loadMeals(date.value);
+});
+watch(normalizedLanguage, async (newLanguage, oldLanguage) => {
   date.value.setHours(12);
   await loadMeals(date.value);
 });


### PR DESCRIPTION
This PR adds a button in the top row to switch the language. It would be great if this were persisted over reloads, but it will suffice as a first implementation.

The button uses the Google Translate logo (as I did not find a better material icon for this) and just switches between German and English, as the API does not accept any other languages.

The button is not visible in the detailed item screen, because people probably only set it once to their preferred language (and because I was too lazy to add another button there).

My lsp also did some things to the file, I can revert those if you don't want them.